### PR TITLE
Default empty state for found nodes

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -191,8 +191,8 @@ exports.sourceNodes = async (gatsbyApi) => {
             }`,
             variables: {}
         });
-        const updatedNodes = data.nodesUpdatedSince;
-        const deletedNodes = data.nodesDeletedSince;
+        const updatedNodes = data.nodesUpdatedSince || [];
+        const deletedNodes = data.nodesDeletedSince || [];
         const nodeEvents = [
             ...updatedNodes.map(entry => {
                 return {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,0 @@
-import React from "react"
-
-export default function Home() {
-    return <div>Hello world!</div>
-}


### PR DESCRIPTION
I was finding that if the check for updates & deletions returned results for one but not the other, `null` was the result of the empty set, and so attempting to map it failed. Falling back to an empty array seemed to fix the issue.

I also deleted the "helloworld" page, as it's probably not desired by most users and could cause confusion as to where it's coming from.